### PR TITLE
Receive Console interface on ConsoleLogger

### DIFF
--- a/src/consoleLogger.ts
+++ b/src/consoleLogger.ts
@@ -1,10 +1,15 @@
-/* eslint-disable no-console -- This is indeed a console logger */
 import {Log, LogDetails, Logger, LogLevel} from './logger';
 
 /**
  * A logger that writes to the console.
  */
 export class ConsoleLogger<T extends LogDetails = LogDetails> implements Logger<T> {
+    private readonly console: Console;
+
+    public constructor(targetConsole: Console = console) {
+        this.console = targetConsole;
+    }
+
     public log(log: Log<T>): void {
         const args = log.details === undefined
             ? [log.message]
@@ -12,19 +17,19 @@ export class ConsoleLogger<T extends LogDetails = LogDetails> implements Logger<
 
         switch (log.level) {
             case LogLevel.DEBUG:
-                console.debug(...args);
+                this.console.debug(...args);
                 break;
 
             case LogLevel.INFO:
-                console.info(...args);
+                this.console.info(...args);
                 break;
 
             case LogLevel.WARNING:
-                console.warn(...args);
+                this.console.warn(...args);
                 break;
 
             case LogLevel.ERROR:
-                console.error(...args);
+                this.console.error(...args);
                 break;
         }
     }

--- a/test/consoleLogger.test.ts
+++ b/test/consoleLogger.test.ts
@@ -1,30 +1,16 @@
 /* eslint-disable no-console -- Needed for testing */
-import {LogLevel} from '../src/logger';
-import {ConsoleLogger} from '../src/consoleLogger';
+import {ConsoleLogger, LogLevel} from '../src';
 
 describe('A console logger', () => {
+    const mockedConsole: jest.MockedObject<Console> = {
+        warn: jest.fn().mockName('warn'),
+        error: jest.fn().mockName('error'),
+        info: jest.fn().mockName('info'),
+        debug: jest.fn().mockName('debug'),
+    } as jest.MockedObject<Console>;
+
     it('should log to the console', () => {
-        jest.spyOn(console, 'debug').mockImplementationOnce(() => {
-            // Suppress the console output
-        });
-
-        jest.spyOn(console, 'info').mockImplementationOnce(() => {
-            // Suppress the console output
-        });
-
-        jest.spyOn(console, 'log').mockImplementationOnce(() => {
-            // Suppress the console output
-        });
-
-        jest.spyOn(console, 'warn').mockImplementationOnce(() => {
-            // Suppress the console output
-        });
-
-        jest.spyOn(console, 'error').mockImplementationOnce(() => {
-            // Suppress the console output
-        });
-
-        const logger = new ConsoleLogger();
+        const logger = new ConsoleLogger(mockedConsole);
 
         logger.log({
             level: LogLevel.DEBUG,
@@ -58,32 +44,32 @@ describe('A console logger', () => {
             },
         });
 
-        expect(console.debug).toHaveBeenCalledTimes(1);
-        expect(console.debug).toHaveBeenCalledWith(
+        expect(mockedConsole.debug).toHaveBeenCalledTimes(1);
+        expect(mockedConsole.debug).toHaveBeenCalledWith(
             'This is a debug message',
             {
                 cause: 'This is a cause',
             },
         );
 
-        expect(console.info).toHaveBeenCalledTimes(1);
-        expect(console.info).toHaveBeenCalledWith(
+        expect(mockedConsole.info).toHaveBeenCalledTimes(1);
+        expect(mockedConsole.info).toHaveBeenCalledWith(
             'This is an info message',
             {
                 cause: 'This is a cause',
             },
         );
 
-        expect(console.warn).toHaveBeenCalledTimes(1);
-        expect(console.warn).toHaveBeenCalledWith(
+        expect(mockedConsole.warn).toHaveBeenCalledTimes(1);
+        expect(mockedConsole.warn).toHaveBeenCalledWith(
             'This is a warning message',
             {
                 cause: 'This is a cause',
             },
         );
 
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(console.error).toHaveBeenCalledWith(
+        expect(mockedConsole.error).toHaveBeenCalledTimes(1);
+        expect(mockedConsole.error).toHaveBeenCalledWith(
             'This is an error message',
             {
                 cause: 'This is a cause',
@@ -92,27 +78,7 @@ describe('A console logger', () => {
     });
 
     it('should omit the details if not specified', () => {
-        jest.spyOn(console, 'debug').mockImplementationOnce(() => {
-            // Suppress the console output
-        });
-
-        jest.spyOn(console, 'info').mockImplementationOnce(() => {
-            // Suppress the console output
-        });
-
-        jest.spyOn(console, 'log').mockImplementationOnce(() => {
-            // Suppress the console output
-        });
-
-        jest.spyOn(console, 'warn').mockImplementationOnce(() => {
-            // Suppress the console output
-        });
-
-        jest.spyOn(console, 'error').mockImplementationOnce(() => {
-            // Suppress the console output
-        });
-
-        const logger = new ConsoleLogger();
+        const logger = new ConsoleLogger(mockedConsole);
 
         logger.log({
             level: LogLevel.DEBUG,
@@ -134,16 +100,16 @@ describe('A console logger', () => {
             message: 'This is an error message',
         });
 
-        expect(console.debug).toHaveBeenCalledTimes(1);
-        expect(console.debug).toHaveBeenCalledWith('This is a debug message');
+        expect(mockedConsole.debug).toHaveBeenCalledTimes(1);
+        expect(mockedConsole.debug).toHaveBeenCalledWith('This is a debug message');
 
-        expect(console.info).toHaveBeenCalledTimes(1);
-        expect(console.info).toHaveBeenCalledWith('This is an info message');
+        expect(mockedConsole.info).toHaveBeenCalledTimes(1);
+        expect(mockedConsole.info).toHaveBeenCalledWith('This is an info message');
 
-        expect(console.warn).toHaveBeenCalledTimes(1);
-        expect(console.warn).toHaveBeenCalledWith('This is a warning message');
+        expect(mockedConsole.warn).toHaveBeenCalledTimes(1);
+        expect(mockedConsole.warn).toHaveBeenCalledWith('This is a warning message');
 
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(console.error).toHaveBeenCalledWith('This is an error message');
+        expect(mockedConsole.error).toHaveBeenCalledTimes(1);
+        expect(mockedConsole.error).toHaveBeenCalledWith('This is an error message');
     });
 });


### PR DESCRIPTION
## Summary

Change the `ConsoleLogger` to receive a `Console` defaulting to the global `console` value. This allows using the same logger on node when [custom console options](https://nodejs.org/api/console.html#class-console) are useful.

On the browser, logging an object allows it to be interacted with on the developer console, expanding its values as much as one might need. On Node, logging a nested object to the console will, by default, only show the first 3 levels.

Example:

```ts
// Very nested details
const logEntry: Log = {
    level: LogLevel.INFO,
    message: 'Some message',
    details: {a1:{a2:{a3:{a4:{a5:{a6:{a7:{a8:{a9:{}}}}}}}}}},
};

const defaultConsoleLogger = new ConsoleLogger();

defaultConsoleLogger.log(logEntry);
/* Output:
Some message { a1: { a2: { a3: [Object] } } }
*/

const customConsoleLogger = new ConsoleLogger(new console.Console({
    stdout: process.stdout,
    stderr: process.stderr,
    inspectOptions: { depth: null },
}));

customConsoleLogger.log(logEntry);
/* Output:
Some message {
  a1: {
    a2: {
      a3: {
        a4: {
          a5: {
            a6: { a7: { a8: { a9: {} } } }
          }
        }
      }
    }
  }
}
*/
```

This also allows logging to a file or any other data stream by passing those to the console instance.

```ts
import * as fs from 'fs';

new ConsoleLogger(new console.Console({
    stdout: fs.createWriteStream('./stdout.log'),
    stderr: fs.createWriteStream('./stderr.log'),
}));
```

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings