### PR TITLE
Implement in-memory logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ This package provides the following implementations:
   A logger that writes to the console using the appropriate console API semantics.
 - [PrefixedLogger](src/prefixedLogger.ts)  
   A logger that prepends a prefix to all log messages.
+- [InMemoryLogger](src/inMemoryLogger.ts)  
+  A logger that stores all log messages in memory.
 
 ## Utilities
 

--- a/src/inMemoryLogger.ts
+++ b/src/inMemoryLogger.ts
@@ -1,0 +1,19 @@
+import {Log, LogDetails, Logger} from './logger';
+
+/**
+ * A logger that saves all logs in memory.
+ */
+export class InMemoryLogger<T extends LogDetails = LogDetails> implements Logger<T> {
+    private readonly logs: Array<Log<T>> = [];
+
+    public log(log: Log<T>): void {
+        this.logs.push(log);
+    }
+
+    /**
+     * Returns all received logs.
+     */
+    public getLogs(): ReadonlyArray<Log<T>> {
+        return this.logs;
+    }
+}

--- a/src/inMemoryLogger.ts
+++ b/src/inMemoryLogger.ts
@@ -1,9 +1,12 @@
 import {Log, Logger} from './logger';
 
 /**
- * A logger that saves all logs in memory.
+ * A logger that stores all logs in memory.
  */
 export class InMemoryLogger<T extends Log = Log> implements Logger<T> {
+    /**
+     * The received logs.
+     */
     private readonly logs: T[] = [];
 
     public log(log: T): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './logger';
 export * from './suppressedLogger';
 export * from './consoleLogger';
+export * from './inMemoryLogger';
 export * from './utilities';

--- a/test/inMemoryLogger.test.ts
+++ b/test/inMemoryLogger.test.ts
@@ -1,0 +1,44 @@
+import {InMemoryLogger, Log, LogLevel} from '../src';
+
+describe('An in-memory logger', () => {
+    it('should log messages', () => {
+        const logger = new InMemoryLogger();
+
+        const logs: Log[] = [
+            {
+                level: LogLevel.DEBUG,
+                message: 'A debug message',
+                details: {
+                    id: 1,
+                },
+            },
+            {
+                level: LogLevel.INFO,
+                message: 'An info message',
+                details: {
+                    id: 2,
+                },
+            },
+            {
+                level: LogLevel.WARNING,
+                message: 'A warning message',
+                details: {
+                    id: 3,
+                },
+            },
+            {
+                level: LogLevel.ERROR,
+                message: 'An error message',
+                details: {
+                    id: 4,
+                },
+            },
+        ];
+
+        for (const log of logs) {
+            logger.log(log);
+        }
+
+        expect(logger.getLogs()).toEqual(logs);
+    });
+});


### PR DESCRIPTION
## Summary

Adds an implementation of `Logger` that stores every log in-memory, useful for testing without having to mock things or to create higher level loggers such as loggers to remote servers, queues and batching.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings