### PR TITLE
Make Logger contravariant over the log type

### DIFF
--- a/src/consoleLogger.ts
+++ b/src/consoleLogger.ts
@@ -1,16 +1,16 @@
-import {Log, LogDetails, Logger, LogLevel} from './logger';
+import {Log, Logger, LogLevel} from './logger';
 
 /**
  * A logger that writes to the console.
  */
-export class ConsoleLogger<T extends LogDetails = LogDetails> implements Logger<T> {
+export class ConsoleLogger<T extends Log = Log> implements Logger<T> {
     private readonly console: Console;
 
     public constructor(targetConsole: Console = console) {
         this.console = targetConsole;
     }
 
-    public log(log: Log<T>): void {
+    public log(log: T): void {
         const args = log.details === undefined
             ? [log.message]
             : [log.message, log.details];

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -53,11 +53,11 @@ export type Log<D extends LogDetails = LogDetails> = {
 /**
  * A common interface for loggers.
  */
-export interface Logger<D extends LogDetails = LogDetails> {
+export interface Logger<L extends Log = Log> {
     /**
      * Logs a message.
      *
      * @param log The log message.
      */
-    log(log: Log<D>): void;
+    log(log: L): void;
 }

--- a/src/prefixedLogger.ts
+++ b/src/prefixedLogger.ts
@@ -1,9 +1,9 @@
-import {Log, LogDetails, Logger} from './logger';
+import {Log, Logger} from './logger';
 
 /**
  * A logger that prepends a prefix to all log messages.
  */
-export class PrefixedLogger<T extends LogDetails = LogDetails> implements Logger<T> {
+export class PrefixedLogger<T extends Log = Log> implements Logger<T> {
     /**
      * The logger to which messages are forwarded.
      */
@@ -25,7 +25,7 @@ export class PrefixedLogger<T extends LogDetails = LogDetails> implements Logger
         this.prefix = prefix;
     }
 
-    public log({message, ...log}: Log<T>): void {
+    public log({message, ...log}: T): void {
         this.logger.log({
             message: `[${this.prefix}] ${message}`,
             ...log,

--- a/src/suppressedLogger.ts
+++ b/src/suppressedLogger.ts
@@ -1,9 +1,9 @@
-import {LogDetails, Logger} from './logger';
+import {Log, Logger} from './logger';
 
 /**
  * A logger that suppresses all logging.
  */
-export class SuppressedLogger<T extends LogDetails = LogDetails> implements Logger<T> {
+export class SuppressedLogger<T extends Log = Log> implements Logger<T> {
     public log(): void {
         // suppress debug logs
     }

--- a/test/varianceTest.ts
+++ b/test/varianceTest.ts
@@ -1,0 +1,17 @@
+import {Log, Logger} from '../src';
+
+declare function make<T>(): T;
+
+declare function receive<T>(x: T): void;
+
+type TestLog = Log<{
+    foo: string,
+}>;
+
+// Covariance Log test:
+//   A custom Log type must be assignable to the base logger type.
+receive<Log>(make<TestLog>());
+
+// Contravariance Logger test:
+//   A base logger must be assignable to a logger with a custom Log type.
+receive<Logger<TestLog>>(make<Logger>());


### PR DESCRIPTION
## Summary

Due to the conditional inside of the `Log` definition, the current `Logger` interface is invariant over the type of the details.
This prevents the intended use case of having a broader logger assignable to classes and functions with typed logging.

The reasoning is: "A logger that can log any object _must_ be able to log a specific object type."

This PR includes a type assinability test to ensure the variance is not broken in the future.

**This is a breaking change.** Consumer must now wrap their details definition with `Log<{ ... }>` before passing it to `Logger`.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings