### PR TITLE
Support readonly properties on log details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "dependencies": {
-        "@croct/json": "^1.0.0"
+        "@croct/json": "^1.1"
       },
       "devDependencies": {
         "@croct/eslint-plugin": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "**/*.ts"
   ],
   "dependencies": {
-    "@croct/json": "^1.0.0"
+    "@croct/json": "^1.1"
   }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,9 +1,9 @@
-import {JsonCompatibleObject} from '@croct/json';
+import {ReadonlyJsonCompatibleObject} from '@croct/json';
 
 /**
  * Additional information about the log message.
  */
-export type LogDetails = JsonCompatibleObject;
+export type LogDetails = ReadonlyJsonCompatibleObject;
 
 /**
  * The severity of the log message.
@@ -48,7 +48,7 @@ export type Log<D extends LogDetails = LogDetails> = {
      * The log message.
      */
     message: string,
-} & (JsonCompatibleObject extends D ? {details?: D} : {details: D});
+} & (LogDetails extends D ? {details?: D} : {details: D});
 
 /**
  * A common interface for loggers.


### PR DESCRIPTION
## Summary

This PR relaxes the constraint on the type of the log details to be anything assignable to `ReadonlyJsonCompatibleObject`.
This allows using objects with read-only properties as log details without having to clone them into a new object.

Considerations:
- This change does not affect any of the implementations provided by this library since none of them mutate the details object.
- Uses of this library either pass a value in place of a `LogDetails`, which still allows any value that was previously allowed.
- External implementations provide their own type, if those are mutable their implementation will still be able to mutate the details since the mutability would be overridden with the generic argument.

As such, this is a non-breaking change. Any object with mutable properties can be passed to a logger that receives an object with read-only properties, it just guaranteed that the logger will not change anything. The opposite is not true.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings