### PR TITLE
Add structured error details extraction

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -21,7 +21,7 @@ export function extractErrorMessage(error: unknown, defaultMessage = 'Unknown er
 }
 
 /**
- * The details extracted from an error of unknown type.
+ * Extracted details about an error value.
  */
 export type ErrorDetails = {
     /** The error message. */
@@ -30,7 +30,7 @@ export type ErrorDetails = {
     /** The stack trace of the error, if available. */
     stack?: string,
 
-    /** The details of the error that caused this error, if any. */
+    /** The details of the error that caused this error, if part of a chain. **/
     cause?: ErrorDetails,
 };
 
@@ -53,8 +53,8 @@ export function extractErrorDetails(error: unknown, defaultMessage = 'Unknown er
 
     if (
         typeof error !== 'object'
-            || !(error instanceof Error)
-                || error.message === ''
+        || !(error instanceof Error)
+        || error.message === ''
     ) {
         return {message: defaultMessage};
     }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -5,6 +5,8 @@
  * @param defaultMessage The default message if no message is available.
  *
  * @returns The message or `null` if no message is available.
+ *
+ * @deprecated use {@link extractErrorDetails}
  */
 export function extractErrorMessage(error: unknown, defaultMessage = 'Unknown error'): string {
     if (error instanceof Error && error.message !== '') {
@@ -16,4 +18,56 @@ export function extractErrorMessage(error: unknown, defaultMessage = 'Unknown er
     }
 
     return defaultMessage;
+}
+
+/**
+ * The details extracted from an error of unknown type.
+ */
+export type ErrorDetails = {
+    /** The error message. */
+    message: string,
+
+    /** The stack trace of the error, if available. */
+    stack?: string,
+
+    /** The details of the error that caused this error, if any. */
+    cause?: ErrorDetails,
+};
+
+/**
+ * Extracts the details from an error of unknown type.
+ *
+ * If the error is a non-empty string, the string itself is used as the message.
+ * Otherwise, if the error is an `Error` with a non-empty message, its message, stack trace, and cause
+ * are extracted; the cause is extracted recursively using the same default message.
+ *
+ * @param error The error to extract the details.
+ * @param defaultMessage The default message if the error is not a non-empty string or an `Error` with a message.
+ *
+ * @returns The extracted details, including the stack trace and the cause, when available.
+ */
+export function extractErrorDetails(error: unknown, defaultMessage = 'Unknown error'): ErrorDetails {
+    if (typeof error === 'string' && error !== '') {
+        return {message: error};
+    }
+
+    if (
+        typeof error !== 'object'
+            || !(error instanceof Error)
+                || error.message === ''
+    ) {
+        return {message: defaultMessage};
+    }
+
+    const details: ErrorDetails = {message: error.message};
+
+    if (error.stack !== undefined) {
+        details.stack = error.stack;
+    }
+
+    if (error.cause !== undefined) {
+        details.cause = extractErrorDetails(error.cause, defaultMessage);
+    }
+
+    return details;
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -39,7 +39,7 @@ export type ErrorDetails = {
  *
  * If the error is a non-empty string, the string itself is used as the message.
  * Otherwise, if the error is an `Error` with a non-empty message, its message, stack trace, and cause
- * are extracted; the cause is extracted recursively using the same default message.
+ * are extracted; causes are extracted recursively up to a fixed depth, ignoring cycles.
  *
  * @param error The error to extract the details.
  * @param defaultMessage The default message if the error is not a non-empty string or an `Error` with a message.
@@ -47,6 +47,17 @@ export type ErrorDetails = {
  * @returns The extracted details, including the stack trace and the cause, when available.
  */
 export function extractErrorDetails(error: unknown, defaultMessage = 'Unknown error'): ErrorDetails {
+    return extractErrorDetailsAtDepth(error, defaultMessage, 0, []);
+}
+
+const MAX_ERROR_CAUSE_DEPTH = 10;
+
+function extractErrorDetailsAtDepth(
+    error: unknown,
+    defaultMessage: string,
+    depth: number,
+    ancestors: Array<unknown>,
+): ErrorDetails {
     if (typeof error === 'string' && error !== '') {
         return {message: error};
     }
@@ -65,8 +76,14 @@ export function extractErrorDetails(error: unknown, defaultMessage = 'Unknown er
         details.stack = error.stack;
     }
 
-    if (error.cause !== undefined) {
-        details.cause = extractErrorDetails(error.cause, defaultMessage);
+    ancestors.push(error);
+
+    if (
+        error.cause !== undefined
+        && depth < MAX_ERROR_CAUSE_DEPTH
+        && !ancestors.includes(error.cause)
+    ) {
+        details.cause = extractErrorDetailsAtDepth(error.cause, defaultMessage, depth + 1, ancestors);
     }
 
     return details;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -30,7 +30,7 @@ export type ErrorDetails = {
     /** The stack trace of the error, if available. */
     stack?: string,
 
-    /** The details of the error that caused this error, if part of a chain. **/
+    /** The details of the error that caused this error, if part of a chain. */
     cause?: ErrorDetails,
 };
 

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -88,6 +88,38 @@ describe('A function for extracting error details', () => {
             cause: {message: 'Cause message.'},
         });
     });
+    it('should ignore a circular cause', () => {
+        const error = new Error('Error message.');
+        const cause = new Error('Cause message.');
+
+        delete error.stack;
+        delete cause.stack;
+        error.cause = cause;
+        cause.cause = error;
+
+        expect(extractErrorDetails(error)).toEqual({
+            message: 'Error message.',
+            cause: {message: 'Cause message.'},
+        });
+    });
+
+    it('should limit the cause recursion depth', () => {
+        const errors = Array.from({length: 12}, (_, index) => new Error(`Error ${index}.`));
+
+        for (let index = 0; index < errors.length - 1; index++) {
+            errors[index].cause = errors[index + 1];
+        }
+
+        let details: ErrorDetails | undefined = extractErrorDetails(errors[0]);
+        const messages: string[] = [];
+
+        while (details !== undefined) {
+            messages.push(details.message);
+            details = details.cause;
+        }
+
+        expect(messages).toEqual(Array.from({length: 11}, (_, index) => `Error ${index}.`));
+    });
 
     it.each<[unknown, string|undefined, string]>([
         [new Error(''), undefined, 'Unknown error'],

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -1,5 +1,4 @@
-/* eslint-disable no-console -- Needed for testing */
-import {extractErrorMessage} from '../src';
+import {ErrorDetails, extractErrorDetails, extractErrorMessage} from '../src';
 
 describe('A function for extracting error messages', () => {
     it.each<[any, string|undefined, string]>([
@@ -18,5 +17,92 @@ describe('A function for extracting error messages', () => {
         message: string,
     ) => {
         expect(extractErrorMessage(error, defaultMessage)).toBe(message);
+    });
+});
+
+describe('A function for extracting error details', () => {
+    it.each<[unknown, string|undefined, ErrorDetails]>([
+        ['Error message.', undefined, {message: 'Error message.'}],
+        ['', undefined, {message: 'Unknown error'}],
+        ['', 'Custom default message', {message: 'Custom default message'}],
+        [null, undefined, {message: 'Unknown error'}],
+        [null, 'Custom default message', {message: 'Custom default message'}],
+        [true, undefined, {message: 'Unknown error'}],
+        [{}, undefined, {message: 'Unknown error'}],
+        [new Error(''), undefined, {message: 'Unknown error'}],
+        [new Error(''), 'Custom default message', {message: 'Custom default message'}],
+    ])('should extract the details of the error %p as %j', (
+        error: unknown,
+        defaultMessage: string | undefined,
+        details: ErrorDetails,
+    ) => {
+        expect(extractErrorDetails(error, defaultMessage)).toEqual(details);
+    });
+
+    it('should extract the message and stack of an error', () => {
+        const error = new Error('Error message.');
+
+        error.stack = 'Error: Error message.\n    at <anonymous>:1:1';
+
+        expect(extractErrorDetails(error)).toEqual({
+            message: 'Error message.',
+            stack: 'Error: Error message.\n    at <anonymous>:1:1',
+        });
+    });
+
+    it('should omit the stack when the error has none', () => {
+        const error = new Error('Error message.');
+
+        delete error.stack;
+
+        expect(extractErrorDetails(error)).toEqual({message: 'Error message.'});
+    });
+
+    it('should recursively extract the details of the cause', () => {
+        const cause = new Error('Cause message.');
+        const error = new Error('Error message.');
+
+        cause.stack = 'Error: Cause message.\n    at <anonymous>:1:1';
+        error.stack = 'Error: Error message.\n    at <anonymous>:2:2';
+        error.cause = cause;
+
+        expect(extractErrorDetails(error)).toEqual({
+            message: 'Error message.',
+            stack: 'Error: Error message.\n    at <anonymous>:2:2',
+            cause: {
+                message: 'Cause message.',
+                stack: 'Error: Cause message.\n    at <anonymous>:1:1',
+            },
+        });
+    });
+
+    it('should extract the message of a string cause', () => {
+        const error = new Error('Error message.');
+
+        error.stack = 'Error: Error message.\n    at <anonymous>:1:1';
+        error.cause = 'Cause message.';
+
+        expect(extractErrorDetails(error)).toEqual({
+            message: 'Error message.',
+            stack: 'Error: Error message.\n    at <anonymous>:1:1',
+            cause: {message: 'Cause message.'},
+        });
+    });
+
+    it.each<[unknown, string|undefined, string]>([
+        [new Error(''), undefined, 'Unknown error'],
+        [new Error(''), 'Custom default message', 'Custom default message'],
+        [{}, undefined, 'Unknown error'],
+        [{}, 'Custom default message', 'Custom default message'],
+    ])('should fall back to "%s" for the unsupported cause %p', (
+        cause: unknown,
+        defaultMessage: string | undefined,
+        causeMessage: string,
+    ) => {
+        const error = new Error('Error message.');
+
+        error.cause = cause;
+
+        expect(extractErrorDetails(error, defaultMessage).cause).toEqual({message: causeMessage});
     });
 });


### PR DESCRIPTION
## Summary

Add a public helper for extracting structured, serializable details from unknown errors, including nested causes. Document its API and cover fallback and recursive behavior with focused tests.

## Changes

- Add `ErrorDetails` with message, optional stack, and recursive cause fields
- Add `extractErrorDetails` with configurable fallback handling
- Document the helper and its return type with JSDoc
- Test string, unsupported, empty-message, stack, and nested-cause cases

## Testing

- `npm test -- --runInBand test/utilities.test.ts` — 26 tests passed
- `npm run validate`
- `npm run lint`